### PR TITLE
Add support for expire_after

### DIFF
--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -85,6 +85,20 @@ def _parse_args() -> argparse.Namespace:
         env_var='MI_ENTITIES',
         help='Microinverter entities that will be sent to MQTT. By default all entities are presented.',
     )
+    cfg_parser.add(
+        '--expire-after',
+        required=False,
+        type=int,
+        default=0,
+        env_var='EXPIRE_AFTER',
+        help=(
+            "Defines the number of seconds after DTU or microinverter entities state expires, if it’s not updated "
+            "(for example due to communication issues). After expiry, entities state becomes unavailable."
+            "By default it is 0, which means that entities never expire. When different than 0, the value shall"
+            "be greater than the query period. This setting does not apply to entities that represent a total amount "
+            "such as daily energy production (they never expire)."
+        ),
+    )
     return cfg_parser.parse_args()
 
 

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -103,7 +103,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 options = _parse_args()
-mqtt_builder = HassMqtt(mi_entities=options.mi_entities)
+mqtt_builder = HassMqtt(mi_entities=options.mi_entities, expire_after=options.expire_after)
 microinverter_type = getattr(MicroinverterType, options.microinverter_type)
 modbus_client = HoymilesModbusTCP(
     host=options.dtu_host, port=options.dtu_port, microinverter_type=microinverter_type, unit_id=options.modbus_unit_id

--- a/hoymiles_mqtt/ha.py
+++ b/hoymiles_mqtt/ha.py
@@ -105,6 +105,8 @@ class HassMqtt:
         Arguments:
             mi_entities: names of entities that shall be handled by tge builder
             post_process: if to cache energy production
+            expire_after: number of seconds after which an entity state should expire. This setting is added to the
+                          entity configuration. Applied only when `expire` flag is set in the entity description.
 
         """
         self._state_topics: Dict = {}


### PR DESCRIPTION
Add support for entities expiration, DTU or microinverter entities may become `unavailable` in Home Assistant after a certain number of seconds when there is no update from `hoymiles-mqtt`

Resolves #3 