### PR TITLE
Fix parsing MI_ENTITIES and PORT_ENTITIES env variables.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.9
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -76,7 +76,6 @@ def _parse_args() -> argparse.Namespace:
         '--mi-entities',
         required=False,
         nargs="+",
-        action='append',
         default=MI_ENTITIES,
         env_var='MI_ENTITIES',
         help='Microinverter entities that will be sent to MQTT. By default all entities are presented.',
@@ -85,7 +84,6 @@ def _parse_args() -> argparse.Namespace:
         '--port-entities',
         required=False,
         nargs="+",
-        action='append',
         default=PORT_ENTITIES,
         env_var='PORT_ENTITIES',
         help="Microinverters' port entities (in fact PV panel entities) that will be sent to MQTT. By default all "


### PR DESCRIPTION
Values specified in these variables were added to the default list of options instead of replacing them.

fixes #15 