### PR TITLE
Support for MQTT TLS connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Publishing of these entities can be controlled with _--port-entities_.
                             User name for MQTT broker [env var: MQTT_USER] (default: None)
       --mqtt-password MQTT_PASSWORD
                             Password to MQTT broker [env var: MQTT_PASSWORD] (default: None)
+      --mqtt-tls            MQTT TLS connection [env var: MQTT_TLS] (default: False)
+      --mqtt-tls-insecure   MQTT TLS insecure connection (only relevant when using with the --mqtt-tls option) [env var:
+                            MQTT_TLS_INSECURE] (default: False)
       --dtu-host DTU_HOST   Address of Hoymiles DTU [env var: DTU_HOST] (default: None)
       --dtu-port DTU_PORT   DTU modbus port [env var: DTU_PORT] (default: 502)
       --modbus-unit-id MODBUS_UNIT_ID

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -32,6 +32,22 @@ def _parse_args() -> argparse.Namespace:
     )
     cfg_parser.add('--mqtt-user', required=False, type=str, env_var='MQTT_USER', help='User name for MQTT broker')
     cfg_parser.add('--mqtt-password', required=False, type=str, env_var='MQTT_PASSWORD', help='Password to MQTT broker')
+    cfg_parser.add(
+        '--mqtt-tls',
+        required=False,
+        default=False,
+        action='store_true',
+        env_var='MQTT_TLS',
+        help='MQTT TLS connection',
+    )
+    cfg_parser.add(
+        '--mqtt-tls-insecure',
+        required=False,
+        default=False,
+        action='store_true',
+        env_var='MQTT_TLS_INSECURE',
+        help='MQTT TLS insecure connection (only relevant when using with the --mqtt-tls option)',
+    )
     cfg_parser.add('--dtu-host', required=True, type=str, env_var='DTU_HOST', help='Address of Hoymiles DTU')
     cfg_parser.add(
         '--dtu-port', required=False, type=int, default=DEFAULT_MODBUS_PORT, env_var='DTU_PORT', help='DTU modbus port'
@@ -163,6 +179,8 @@ mqtt_publisher = MqttPublisher(
     mqtt_port=options.mqtt_port,
     mqtt_user=options.mqtt_user,
     mqtt_password=options.mqtt_password,
+    mqtt_tls=options.mqtt_tls,
+    mqtt_tls_insecure=options.mqtt_tls_insecure,
 )
 query_job = HoymilesQueryJob(mqtt_builder=mqtt_builder, mqtt_publisher=mqtt_publisher, modbus_client=modbus_client)
 run_periodic_job(period=options.query_period, job=query_job.execute)

--- a/hoymiles_mqtt/mqtt.py
+++ b/hoymiles_mqtt/mqtt.py
@@ -36,7 +36,7 @@ class MqttPublisher:
         if mqtt_tls:
             self._tls = {'tls_version': ssl.PROTOCOL_TLS_CLIENT}
             if mqtt_tls_insecure:
-                self._tls = {'insecure': True, 'tls_version': ssl.PROTOCOL_TLS_CLIENT}
+                self._tls['insecure'] = True
 
     def publish(self, topic: str, message: str, retain: bool = False) -> None:
         """Publish a message to the given MQTT topic.

--- a/hoymiles_mqtt/mqtt.py
+++ b/hoymiles_mqtt/mqtt.py
@@ -1,11 +1,21 @@
 """MQTT related interfaces."""
+import ssl
+
 from paho.mqtt.publish import single as publish_single
 
 
 class MqttPublisher:
     """MQTT Publisher."""
 
-    def __init__(self, mqtt_broker: str, mqtt_port: int, mqtt_user: str = None, mqtt_password: str = None):
+    def __init__(
+        self,
+        mqtt_broker: str,
+        mqtt_port: int,
+        mqtt_user: str = None,
+        mqtt_password: str = None,
+        mqtt_tls: bool = False,
+        mqtt_tls_insecure: bool = False,
+    ):
         """Initialize the object.
 
         Arguments:
@@ -13,6 +23,8 @@ class MqttPublisher:
             mqtt_port: port of MQTT broker
             mqtt_user: MQTT username
             mqtt_password: password
+            mqtt_tls: TLS connection
+            mqtt_tls_insecure: TLS insecure connection
 
         """
         self._mqtt_broker = mqtt_broker
@@ -20,6 +32,11 @@ class MqttPublisher:
         self._auth = None
         if mqtt_user and mqtt_password:
             self._auth = {'username': mqtt_user, 'password': mqtt_password}
+        self._tls = None
+        if mqtt_tls:
+            self._tls = {'tls_version': ssl.PROTOCOL_TLS_CLIENT}
+            if mqtt_tls_insecure:
+                self._tls = {'insecure': True, 'tls_version': ssl.PROTOCOL_TLS_CLIENT}
 
     def publish(self, topic: str, message: str, retain: bool = False) -> None:
         """Publish a message to the given MQTT topic.
@@ -37,4 +54,5 @@ class MqttPublisher:
             port=self._mqtt_port,
             auth=self._auth,
             retain=retain,
+            tls=self._tls,
         )


### PR DESCRIPTION
Two parameters have been added to enable an encrypted connection to the MQTT server. 

We can enable TLS support via --mqtt-tls.

In case the certificate is signed by an unknown CA, we can enable insecure TLS connection via --mqtt-tls-insecure. 