### PR TITLE
New feature: --mqtt-topic

### DIFF
--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -15,6 +15,7 @@ DEFAULT_MQTT_PORT = 1883
 DEFAULT_MODBUS_PORT = 502
 DEFAULT_QUERY_PERIOD_SEC = 60
 DEFAULT_MODBUS_UNIT_ID = 1
+DEFAULT_TOPIC = 'homeassistant/hoymiles_mqtt'
 
 logger = logging.getLogger(__name__)
 
@@ -196,6 +197,14 @@ def _parse_args() -> argparse.Namespace:
         env_var='LOG_FILE',
         help="Python logger log file. Default: not writing into a file",
     )
+    cfg_parser.add(
+        '--mqtt-topic',
+        required=False,
+        type=str,
+        default=DEFAULT_TOPIC,
+        env_var='MQTT_TOPIC',
+        help=f"MQTT topic to base all output data.",
+    )
     return cfg_parser.parse_args()
 
 
@@ -204,7 +213,8 @@ def main():
     options = _parse_args()
     _setup_logger(options)
     mqtt_builder = HassMqtt(
-        mi_entities=options.mi_entities, port_entities=options.port_entities, expire_after=options.expire_after
+        mi_entities=options.mi_entities, port_entities=options.port_entities, expire_after=options.expire_after,
+        topic_base=options.mqtt_topic
     )
     microinverter_type = getattr(MicroinverterType, options.microinverter_type)
     modbus_client = HoymilesModbusTCP(

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -32,6 +32,8 @@ def _setup_logger(options: configargparse.Namespace) -> None:
     # Modbus is a noisy library. Especially on DEBUG-level.
     pymodbus_log = logging.getLogger('pymodbus')
     pymodbus_log.setLevel(logging.INFO)
+    paho_log = logging.getLogger('paho')
+    paho_log.setLevel(logging.INFO)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/hoymiles_mqtt/ha.py
+++ b/hoymiles_mqtt/ha.py
@@ -148,9 +148,11 @@ class HassMqtt:
     """MQTT message builder for Home Assistant."""
 
     RESET_HOUR: int = 22
+    CONFIG_TOPIC_BASE: str = 'homeassistant'
 
     def __init__(
         self, mi_entities: List[str], port_entities: List[str],
+        topic_base: str,
         post_process: bool = True, expire_after: int = 0
     ) -> None:
         """Initialize the object.
@@ -164,6 +166,7 @@ class HassMqtt:
 
         """
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._topic_base: str = topic_base
         self._state_topics: Dict = {}
         self._config_topics: Dict = {}
         self._post_process: bool = post_process
@@ -182,15 +185,14 @@ class HassMqtt:
 
     @staticmethod
     def _get_config_topic(platform: str, device_serial: str, entity_name) -> str:
-        return f"homeassistant/{platform}/{device_serial}/{entity_name}/config"
+        return f"{HassMqtt.CONFIG_TOPIC_BASE}/{platform}/{device_serial}/{entity_name}/config"
 
-    @staticmethod
-    def _get_state_topic(device_serial: str, port: Optional[int]) -> str:
+    def _get_state_topic(self, device_serial: str, port: Optional[int]) -> str:
         if port is not None:
             sub_topic = f'{device_serial}/{port}'
         else:
             sub_topic = device_serial
-        return f"homeassistant/hoymiles_mqtt/{sub_topic}/state"
+        return f"{self._topic_base}/{sub_topic}/state"
 
     def _get_config_payloads(
         self,


### PR DESCRIPTION
MQTT shouldn't be that tightly coupled into Home Assistant.
In MQTT there is no discovery, in Home Assistant there is.
As there might be multiple subscribes to change topic, binding it with a hard-coded value into Home Assistant isn't especially good approach.

Having the topic default into previous value, there is no breaking change. However, soft-coding the topic improves feasibility to any setup, enabling the MQTT topics to be arranged as best suited.

Note:
As Home Assistant depends heavily with the discovery and given discovery topic can not be changed, moving the actual data feed does not break existing Home Assistant setups at all. HA simply reads the data from new topics without gaps in the existing data.