### PR TITLE
Fix not clean stopping

### DIFF
--- a/hoymiles_mqtt/__init__.py
+++ b/hoymiles_mqtt/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for Hoymiles MQTT."""
 
+import logging
+
 __author__ = """Foo Bar"""
 __email__ = 'foo@bar.com'
 __version__ = '0.8.0'
@@ -15,3 +17,5 @@ MI_ENTITIES = [
 ]
 
 PORT_ENTITIES = ['pv_voltage', 'pv_current', 'pv_power', 'today_production', 'total_production']
+
+_main_logger = logging.getLogger(__name__)

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -8,7 +8,7 @@ import configargparse
 from hoymiles_modbus.client import HoymilesModbusTCP
 from hoymiles_modbus.datatypes import MicroinverterType
 
-from hoymiles_mqtt import MI_ENTITIES, PORT_ENTITIES
+from hoymiles_mqtt import MI_ENTITIES, PORT_ENTITIES, _main_logger
 from hoymiles_mqtt.ha import HassMqtt
 from hoymiles_mqtt.mqtt import MqttPublisher
 from hoymiles_mqtt.runners import HoymilesQueryJob, run_periodic_job
@@ -18,12 +18,10 @@ DEFAULT_MODBUS_PORT = 502
 DEFAULT_QUERY_PERIOD_SEC = 60
 DEFAULT_MODBUS_UNIT_ID = 1
 
-logger = logging.getLogger(__name__)
+logger = _main_logger.getChild(__name__)
 
 
 def _setup_logger(options: configargparse.Namespace) -> None:
-    log_level = logging.getLevelName(options.log_level)
-
     handlers: list[logging.Handler] = []
     if options.log_to_console:
         handlers.append(logging.StreamHandler(sys.stdout))
@@ -32,12 +30,9 @@ def _setup_logger(options: configargparse.Namespace) -> None:
 
     logging.basicConfig(
         format="%(asctime)s [%(threadName)-12.12s] [%(levelname)-5.5s]  [%(name)s] %(message)s",
-        level=log_level,
         handlers=handlers,
     )
-    # Modbus is a noisy library. Especially on DEBUG-level.
-    pymodbus_log = logging.getLogger('pymodbus')
-    pymodbus_log.setLevel(logging.INFO)
+    _main_logger.setLevel(options.log_level)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/hoymiles_mqtt/__main__.py
+++ b/hoymiles_mqtt/__main__.py
@@ -18,7 +18,7 @@ DEFAULT_MODBUS_PORT = 502
 DEFAULT_QUERY_PERIOD_SEC = 60
 DEFAULT_MODBUS_UNIT_ID = 1
 
-logger = _main_logger.getChild(__name__)
+logger = _main_logger.getChild('__main__')
 
 
 def _setup_logger(options: configargparse.Namespace) -> None:

--- a/hoymiles_mqtt/ha.py
+++ b/hoymiles_mqtt/ha.py
@@ -1,13 +1,12 @@
 """MQTT message builders for Home Assistant."""
 
 import json
-import logging
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from hoymiles_modbus.datatypes import PlantData
 
-logger = logging.getLogger(__name__)
+from hoymiles_mqtt import _main_logger
 
 PLATFORM_SENSOR = 'sensor'
 PLATFORM_BINARY_SENSOR = 'binary_sensor'
@@ -160,7 +159,7 @@ class HassMqtt:
                           entity configuration. Applied only when `expire` flag is set in the entity description.
 
         """
-        self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger = _main_logger.getChild(self.__class__.__name__)
         self._state_topics: Dict = {}
         self._config_topics: Dict = {}
         self._post_process: bool = post_process

--- a/hoymiles_mqtt/ha.py
+++ b/hoymiles_mqtt/ha.py
@@ -8,6 +8,8 @@ from hoymiles_modbus.datatypes import PlantData
 
 from hoymiles_mqtt import _main_logger
 
+logger = _main_logger.getChild('ha')
+
 PLATFORM_SENSOR = 'sensor'
 PLATFORM_BINARY_SENSOR = 'binary_sensor'
 
@@ -159,7 +161,7 @@ class HassMqtt:
                           entity configuration. Applied only when `expire` flag is set in the entity description.
 
         """
-        self._logger = _main_logger.getChild(self.__class__.__name__)
+        self._logger = logger
         self._state_topics: Dict = {}
         self._config_topics: Dict = {}
         self._post_process: bool = post_process

--- a/hoymiles_mqtt/mqtt.py
+++ b/hoymiles_mqtt/mqtt.py
@@ -1,6 +1,5 @@
 """MQTT related interfaces."""
 
-import logging
 import ssl
 from typing import TYPE_CHECKING, Optional
 
@@ -8,8 +7,6 @@ from paho.mqtt.publish import single as publish_single
 
 if TYPE_CHECKING:
     from paho.mqtt.publish import AuthParameter, TLSParameter
-
-logger = logging.getLogger(__name__)
 
 
 class MqttPublisher:

--- a/hoymiles_mqtt/runners.py
+++ b/hoymiles_mqtt/runners.py
@@ -39,60 +39,64 @@ class HoymilesQueryJob:
         """Get data from DTU and publish to MQTT broker."""
         is_acquired = self._lock.acquire(blocking=False)
         if not is_acquired:
+            logger.warning(
+                'Previous data acquire and send was not finished before '
+                'starting the next loop. Perhaps query period is too small.'
+            )
             return
-
-        if time.localtime().tm_hour == RESET_HOUR:
-            self._mqtt_builder.clear_production_today()
-            logger.info("Reset hour reached")
-
-        logger.debug("Read data from DTU")
-        plant_data = None
-        publish_count = 0
         try:
-            plant_data = self._modbus_client.plant_data
-            logger.debug("Received data from DTU")
-        except pymodbus_exceptions.ModbusIOException as exc:
-            if 'No response received, expected at least 8 bytes' in exc.message:
-                logger.warning("Failed to read data from DTU via Modbus. Will retry.")
-            else:
-                logger.exception("Failed to read data from DTU via Modbus.")
-        except Exception:
-            logger.exception("Failed to read data from DTU. Unknown failure type.")
+            if time.localtime().tm_hour == RESET_HOUR:
+                self._mqtt_builder.clear_production_today()
+                logger.info("Reset hour reached")
 
-        if plant_data:
+            logger.debug("Read data from DTU")
+            plant_data = None
+            publish_count = 0
             try:
-                # Publish configurations?
-                # This is done only for the first data set
-                if not self._mqtt_configured:
-                    for topic, payload in self._mqtt_builder.get_configs(plant_data=plant_data):
-                        self._mqtt_publisher.publish(topic=topic, message=payload, retain=True)
+                plant_data = self._modbus_client.plant_data
+                logger.debug("Received data from DTU")
+            except pymodbus_exceptions.ModbusIOException as exc:
+                if 'No response received, expected at least 8 bytes' in exc.message:
+                    logger.warning("Failed to read data from DTU via Modbus. Will retry.")
+                else:
+                    logger.exception("Failed to read data from DTU via Modbus.")
+            except Exception:
+                logger.exception("Failed to read data from DTU. Unknown failure type.")
+
+            if plant_data:
+                try:
+                    # Publish configurations?
+                    # This is done only for the first data set
+                    if not self._mqtt_configured:
+                        for topic, payload in self._mqtt_builder.get_configs(plant_data=plant_data):
+                            self._mqtt_publisher.publish(topic=topic, message=payload, retain=True)
+                            mqtt_broker = "mqtt://{}:{}/{}".format(
+                                self._mqtt_publisher._mqtt_broker, self._mqtt_publisher._mqtt_port, topic
+                            )
+                            logger.debug("Published config into {}".format(mqtt_broker))
+                        self._mqtt_configured = True
+
+                    # Publish data
+                    for topic, payload in self._mqtt_builder.get_states(plant_data=plant_data):
+                        self._mqtt_publisher.publish(topic=topic, message=payload)
+                        publish_count += 1
                         mqtt_broker = "mqtt://{}:{}/{}".format(
                             self._mqtt_publisher._mqtt_broker, self._mqtt_publisher._mqtt_port, topic
                         )
-                        logger.debug("Published config into {}".format(mqtt_broker))
-                    self._mqtt_configured = True
+                        logger.debug("Published data into %s", mqtt_broker)
+                except Exception:
+                    logger.exception("Failed to publish data from DTU. Unknown failure type.")
 
-                # Publish data
-                for topic, payload in self._mqtt_builder.get_states(plant_data=plant_data):
-                    self._mqtt_publisher.publish(topic=topic, message=payload)
-                    publish_count += 1
-                    mqtt_broker = "mqtt://{}:{}/{}".format(
-                        self._mqtt_publisher._mqtt_broker, self._mqtt_publisher._mqtt_port, topic
-                    )
-                    logger.debug("Published data into %s", mqtt_broker)
-            except Exception:
-                logger.exception("Failed to publish data from DTU. Unknown failure type.")
-
-            logger.info(
-                "DTU data received and published. %s messages into mqtt://%s:%d",
-                publish_count,
-                self._mqtt_publisher._mqtt_broker,
-                self._mqtt_publisher._mqtt_port,
-            )
-        else:
-            logger.warning("No DTU data received!")
-
-        self._lock.release()
+                logger.info(
+                    "DTU data received and published. %s messages into mqtt://%s:%d",
+                    publish_count,
+                    self._mqtt_publisher._mqtt_broker,
+                    self._mqtt_publisher._mqtt_port,
+                )
+            else:
+                logger.warning("No DTU data received!")
+        finally:
+            self._lock.release()
 
 
 def run_periodic_job(period: int, job: Callable) -> None:
@@ -105,10 +109,20 @@ def run_periodic_job(period: int, job: Callable) -> None:
     """
     running = True
     logger.info("Begin looping messages")
+
+    def exception_handler(args):
+        logger.error(
+            "Unhandled exception during data acquire and send thread",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    threading.excepthook = exception_handler
     while running:
+        thread = threading.Thread(target=job)
+        logger.debug('Start acquire and send thread')
         try:
-            threading.Thread(target=job).start()
-            time.sleep(period)
+            thread.start()
         except KeyboardInterrupt:
             running = False
+        time.sleep(period)
     logger.info("Done looping messages")

--- a/hoymiles_mqtt/runners.py
+++ b/hoymiles_mqtt/runners.py
@@ -12,7 +12,7 @@ from hoymiles_mqtt import _main_logger
 from hoymiles_mqtt.ha import HassMqtt
 from hoymiles_mqtt.mqtt import MqttPublisher
 
-logger = _main_logger.getChild(__name__)
+logger = _main_logger.getChild('runners')
 
 RESET_HOUR = 23
 

--- a/hoymiles_mqtt/runners.py
+++ b/hoymiles_mqtt/runners.py
@@ -1,6 +1,5 @@
 """Runners."""
 
-import logging
 import threading
 import time
 from typing import Callable
@@ -8,10 +7,11 @@ from typing import Callable
 from hoymiles_modbus.client import HoymilesModbusTCP
 from pymodbus import exceptions as pymodbus_exceptions
 
+from hoymiles_mqtt import _main_logger
 from hoymiles_mqtt.ha import HassMqtt
 from hoymiles_mqtt.mqtt import MqttPublisher
 
-logger = logging.getLogger(__name__)
+logger = _main_logger.getChild(__name__)
 
 RESET_HOUR = 23
 


### PR DESCRIPTION
hoymiles-mqtt was not stopping cleanly,  many threads were left forever and consuming CPU power. Support for system signals was introduced for graceful process termination.
Additionally, logging was reworked to not log events from sub-dependencies (they were spamming logs).

Fixes #33 